### PR TITLE
Lightweight spec-driven skills

### DIFF
--- a/skills/spec-driven/SKILL.md
+++ b/skills/spec-driven/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: spec-driven
+description: "Spec-driven project methodology reference. Use when a project has a specs/ folder for managing product requirements, vision, goals, architecture, decision records (ADR), glossary, changelog, and ticket-based work tracking. Loaded when: working on a project with specs/; reading or updating PRD, vision, goals, architecture, or glossary; detecting drift between code and specs; reviewing project methodology or document formats. Triggers on: 'specs', 'PRD', 'vision', 'goals', 'architecture', 'ADR', 'decision record', 'glossary', 'changelog', 'ticket', 'project methodology', 'ground truth'."
+---
+
+# Spec-Driven Development
+
+A methodology for collaborative human-agent project management where all requirements, decisions, and work are documented in a `specs/` folder that serves as the project's single source of truth.
+
+## Skill Dependencies
+
+This skill is part of a set of four skills designed to work together:
+
+| Skill | Purpose |
+|-------|---------|
+| **spec-driven** (this skill) | Methodology reference — structure, formats, rules |
+| **specs-setup** | Initialize `specs/` for a new project |
+| **specs-tickets** | Create and execute tickets through their lifecycle |
+
+If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding. All three skills should be installed together.
+
+## Core Principles
+
+1. **Specs are the ground truth.** When code and specs disagree, the specs win. Either update the code or create an ADR to change the specs.
+2. **Decisions are recorded.** Every change to Vision, PRD, Goals, or Architecture is documented with an Architecture Decision Record.
+3. **Work is traceable.** Every ticket captures research, requirements, plans, and tasks so future contributors understand not just WHAT was built but WHY.
+4. **Humans decide, agents execute and propose.** Agents can research, draft specs, plan, and implement — but key decisions (scope, architecture, trade-offs) require human confirmation.
+5. **Progressive documentation.** Create documents when needed, not proactively. A small bug fix doesn't need Research.md.
+
+## Truth Hierarchy
+
+When documents conflict, the higher-level document takes precedence:
+
+```
+Vision.md > PRD.md / Goals.md > Architecture/ > Ticket Spec.md > Ticket Plan.md > Ticket Tasks.md
+```
+
+Conflicts must be resolved by either:
+- Creating an ADR and updating the higher-level document
+- Creating a ticket to fix the lower-level document or code
+
+## Folder Structure
+
+```
+specs/
+├── README.md                    # Project dashboard and navigation
+├── Vision.md                    # WHY — vision, problem statement, target audience
+├── PRD.md                       # WHAT — functional and non-functional requirements
+├── Goals.md                     # HOW WE MEASURE — success metrics, KPIs, milestones
+├── Glossary.md                  # Domain vocabulary
+├── Changelog.md                 # What shipped and when
+├── Architecture/                # Architecture documentation (always a folder)
+│   ├── README.md                # Architecture overview (entry point)
+│   └── <topic>.md               # Sub-documents split by concern
+├── decisions/                   # Architecture Decision Records
+│   ├── ADR-001-<title>.md
+│   └── ...
+└── tickets/                     # Work items
+    └── <NNN>-<slug>/            # e.g., 001-user-auth/
+        ├── README.md            # Ticket metadata and summary
+        ├── Research.md          # Investigation findings (optional)
+        ├── Spec.md              # Requirements and acceptance criteria
+        ├── Plan.md              # Implementation approach (optional)
+        ├── Tasks.md             # Task checklist
+        ├── Dependencies.md      # Cross-ticket dependencies (optional)
+        ├── Decisions.md         # Open questions and resolved decisions (optional)
+        └── Journal.md           # Process record (optional)
+```
+
+## Project-Level Documents
+
+| Document | Purpose | Required |
+|----------|---------|----------|
+| `README.md` | Project dashboard. Status, active tickets, recent ADRs, navigation. **Read this first in every conversation.** | Always |
+| `Vision.md` | **WHY** — Vision statement, problem statement, target audience and personas. Rarely changes. | Always |
+| `PRD.md` | **WHAT** — Functional requirements, non-functional requirements, scope, assumptions & constraints. Traditional PRD scope. | Always |
+| `Goals.md` | **HOW WE MEASURE** — Success metrics, KPIs, milestones. Reviewed periodically. | Always |
+| `Architecture/README.md` | **HOW IT'S BUILT** — System overview, components, tech stack, constraints. Links to sub-documents. | Always |
+| `Glossary.md` | Domain terms and definitions. Keeps language consistent across all documents. | Always |
+| `Changelog.md` | Shipped changes in reverse chronological order. | Always |
+| `ADR-NNN-<title>.md` | Records a decision that changed Vision, PRD, Goals, or Architecture. | Per decision |
+
+## Ticket-Level Documents
+
+| Document | Purpose | Required |
+|----------|---------|----------|
+| `README.md` | Ticket metadata (status, owner, dates, Jira link) and one-paragraph summary. | Per ticket |
+| `Research.md` | Investigation findings, options considered, feasibility. | When research was done |
+| `Spec.md` | The contract: user stories, acceptance criteria, scope boundaries. | Per ticket |
+| `Plan.md` | Implementation strategy — high-level approach, key design decisions, risks. | At planning phase |
+| `Tasks.md` | Concrete task breakdown with checkboxes. | At task definition phase |
+| `Dependencies.md` | What this ticket blocks or is blocked by. | When dependencies exist |
+| `Decisions.md` | Questions raised and decisions made. Open questions at the top, resolved decisions at the bottom. Becomes a decision record once all questions are answered. | When decisions arise |
+| `Journal.md` | Chronological record of key decisions, pivots, and process. Not a chat transcript. | For non-trivial tickets |
+
+For complete document templates, see [templates.md](./references/templates.md).
+
+## Architecture Folder Guidelines
+
+The `Architecture/` folder starts with a single `README.md` as the entry point. Keep architecture documentation high-level and navigable:
+
+- **Start with README.md.** It alone is sufficient for most projects.
+- **Split when a section exceeds ~200 lines** or covers a distinct concern (data model, API contracts, infrastructure).
+- **New files go alongside README.md** and are linked from it (e.g., `data-model.md`, `api-contracts.md`).
+- **Never nest deeper than one level** within `Architecture/`. If you need sub-folders, the architecture docs are too detailed — summarize and elevate.
+- **Keep each file focused** on one architectural concern.
+
+## Ticket Naming
+
+Tickets use sequential numbering with a descriptive slug:
+
+```
+<NNN>-<slug>/
+```
+
+- `NNN`: Three-digit sequential number, zero-padded (001, 002, ...).
+- `slug`: Lowercase, hyphen-separated description (e.g., `user-auth`, `search-api`).
+- The Jira issue key is stored in the ticket's `README.md` frontmatter, **not** in the folder name.
+- To determine the next number, scan existing ticket folders and increment the highest by one.
+
+## Ticket README Frontmatter
+
+Every ticket has a `README.md` with this frontmatter:
+
+```yaml
+---
+id: "<NNN>"
+title: "<Descriptive title>"
+status: research | specifying | open-questions | planned | in-progress | done | archived
+jira: ""             # Optional: Jira issue key (e.g., YAI-042)
+owner: ""            # Who is responsible
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+```
+
+**Status values:**
+
+| Status | Meaning |
+|--------|---------|
+| `research` | Investigating the problem space |
+| `specifying` | Writing or refining the spec |
+| `open-questions` | Blocked on decisions the user must make |
+| `planned` | Plan and/or tasks defined, ready for implementation |
+| `in-progress` | Implementation underway |
+| `done` | All acceptance criteria met, work complete |
+| `archived` | Ticket closed without completion. **The reason for archival (superseded, cancelled, etc.) must be documented clearly in the ticket's README.md body.** |
+
+## Ticket Lifecycle
+
+```
+Research → Specify → Plan → Define Tasks → Implement → Done
+```
+
+| Phase | Files Produced | Requires User Validation |
+|-------|---------------|--------------------------|
+| Research | Research.md | No (user may review) |
+| Specify | Spec.md, Decisions.md, Dependencies.md | **Yes — user must validate Spec.md** |
+| Plan | Plan.md | **Yes — user must confirm Plan.md** |
+| Define Tasks | Tasks.md | **Yes — user must validate Tasks.md** |
+| Implement | Code + tests | Per task as appropriate |
+| Done | Update README.md status, Changelog.md | **Yes — user confirms completion** |
+
+**Any participant (human or agent) can execute any phase.** The lifecycle defines the *order*, not who does what. The user may write the spec themselves, or the agent may do the research. Flexibility is expected.
+
+## Drift Detection
+
+At the start of every conversation on a project with `specs/`:
+
+1. Read `specs/README.md`, then `Vision.md`, `PRD.md`, `Goals.md`, and `Architecture/README.md`.
+2. If the current code or task contradicts these documents, **alert the user immediately**.
+3. Resolution options:
+   - Create an ADR to update the specs (if the code is right and specs are outdated)
+   - Create a ticket to fix the code (if the specs are right and code has drifted)
+
+## ADR Trigger Rules
+
+Create an Architecture Decision Record when:
+
+- A requirement in Vision.md, PRD.md, or Goals.md changes
+- The architecture is modified (new component, technology change, pattern shift)
+- A ticket implementation reveals that specs need updating
+- A significant decision is made that future contributors should understand
+
+## ADR Format
+
+```markdown
+# ADR-NNN: <Title>
+
+**Status**: Proposed | Accepted | Deprecated | Superseded by ADR-NNN
+**Date**: YYYY-MM-DD
+**Ticket**: <link to related ticket, if any>
+
+## Context
+What situation or problem prompted this decision?
+
+## Decision
+What did we decide?
+
+## Consequences
+What are the trade-offs? What becomes easier? What becomes harder?
+```
+
+## Operational Standards Check
+
+If the project lacks coding standards (e.g., `.instructions.md`, `CLAUDE.md`, `copilot-instructions.md`), **prompt the user to create them before starting any implementation work.** Coding standards define HOW to build; specs define WHAT to build. Both are required.
+
+Coding standards live in their respective configuration files — not in `specs/`.

--- a/skills/spec-driven/SKILL.md
+++ b/skills/spec-driven/SKILL.md
@@ -11,14 +11,18 @@ A methodology for collaborative human-agent project management where all require
 
 This skill is part of a set of four skills designed to work together:
 
-| Skill | Purpose |
-|-------|---------|
-| **spec-driven** (this skill) | Methodology reference — structure, formats, rules |
-| **specs-setup** | Initialize `specs/` for a new project |
-| **specs-tickets** | Create and execute tickets through their lifecycle |
-| **specs-review** | Audit specs health, consistency, and drift |
+| Skill                        | Purpose                                            |
+| ---------------------------- | -------------------------------------------------- |
+| **spec-driven** (this skill) | Methodology reference — structure, formats, rules  |
+| **specs-setup**              | Initialize `specs/` for a new project              |
+| **specs-tickets**            | Create and execute tickets through their lifecycle |
+| **specs-review**             | Audit specs health, consistency, and drift         |
 
-If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding. All three skills should be installed together.
+If any of these skills are missing from the project, **instruct the user to install them** before proceeding:
+
+```bash
+npx skills add b12consulting/skills --skill <missing_skill>
+```
 
 ## Core Principles
 
@@ -37,6 +41,7 @@ Vision.md > PRD.md / Goals.md > Architecture/ > Ticket Spec.md > Ticket Plan.md 
 ```
 
 Conflicts must be resolved by either:
+
 - Creating an ADR and updating the higher-level document
 - Creating a ticket to fix the lower-level document or code
 
@@ -70,29 +75,29 @@ specs/
 
 ## Project-Level Documents
 
-| Document | Purpose | Required |
-|----------|---------|----------|
-| `README.md` | Project dashboard. Status, active tickets, recent ADRs, navigation. **Read this first in every conversation.** | Always |
-| `Vision.md` | **WHY** — Vision statement, problem statement, target audience and personas. Rarely changes. | Always |
-| `PRD.md` | **WHAT** — Functional requirements, non-functional requirements, scope, assumptions & constraints. Traditional PRD scope. | Always |
-| `Goals.md` | **HOW WE MEASURE** — Success metrics, KPIs, milestones. Reviewed periodically. | Always |
-| `Architecture/README.md` | **HOW IT'S BUILT** — System overview, components, tech stack, constraints. Links to sub-documents. | Always |
-| `Glossary.md` | Domain terms and definitions. Keeps language consistent across all documents. | Always |
-| `Changelog.md` | Shipped changes in reverse chronological order. | Always |
-| `ADR-NNN-<title>.md` | Records a decision that changed Vision, PRD, Goals, or Architecture. | Per decision |
+| Document                 | Purpose                                                                                                                   | Required     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `README.md`              | Project dashboard. Status, active tickets, recent ADRs, navigation. **Read this first in every conversation.**            | Always       |
+| `Vision.md`              | **WHY** — Vision statement, problem statement, target audience and personas. Rarely changes.                              | Always       |
+| `PRD.md`                 | **WHAT** — Functional requirements, non-functional requirements, scope, assumptions & constraints. Traditional PRD scope. | Always       |
+| `Goals.md`               | **HOW WE MEASURE** — Success metrics, KPIs, milestones. Reviewed periodically.                                            | Always       |
+| `Architecture/README.md` | **HOW IT'S BUILT** — System overview, components, tech stack, constraints. Links to sub-documents.                        | Always       |
+| `Glossary.md`            | Domain terms and definitions. Keeps language consistent across all documents.                                             | Always       |
+| `Changelog.md`           | Shipped changes in reverse chronological order.                                                                           | Always       |
+| `ADR-NNN-<title>.md`     | Records a decision that changed Vision, PRD, Goals, or Architecture.                                                      | Per decision |
 
 ## Ticket-Level Documents
 
-| Document | Purpose | Required |
-|----------|---------|----------|
-| `README.md` | Ticket metadata (status, owner, dates, Jira link) and one-paragraph summary. | Per ticket |
-| `Research.md` | Investigation findings, options considered, feasibility. | When research was done |
-| `Spec.md` | The contract: user stories, acceptance criteria, scope boundaries. | Per ticket |
-| `Plan.md` | Implementation strategy — high-level approach, key design decisions, risks. | At planning phase |
-| `Tasks.md` | Concrete task breakdown with checkboxes. | At task definition phase |
-| `Dependencies.md` | What this ticket blocks or is blocked by. | When dependencies exist |
-| `Decisions.md` | Questions raised and decisions made. Open questions at the top, resolved decisions at the bottom. Becomes a decision record once all questions are answered. | When decisions arise |
-| `Journal.md` | Chronological record of key decisions, pivots, and process. Not a chat transcript. | For non-trivial tickets |
+| Document          | Purpose                                                                                                                                                      | Required                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| `README.md`       | Ticket metadata (status, owner, dates, Jira link) and one-paragraph summary.                                                                                 | Per ticket               |
+| `Research.md`     | Investigation findings, options considered, feasibility.                                                                                                     | When research was done   |
+| `Spec.md`         | The contract: user stories, acceptance criteria, scope boundaries.                                                                                           | Per ticket               |
+| `Plan.md`         | Implementation strategy — high-level approach, key design decisions, risks.                                                                                  | At planning phase        |
+| `Tasks.md`        | Concrete task breakdown with checkboxes.                                                                                                                     | At task definition phase |
+| `Dependencies.md` | What this ticket blocks or is blocked by.                                                                                                                    | When dependencies exist  |
+| `Decisions.md`    | Questions raised and decisions made. Open questions at the top, resolved decisions at the bottom. Becomes a decision record once all questions are answered. | When decisions arise     |
+| `Journal.md`      | Chronological record of key decisions, pivots, and process. Not a chat transcript.                                                                           | For non-trivial tickets  |
 
 For complete document templates, see [templates.md](./references/templates.md).
 
@@ -128,8 +133,8 @@ Every ticket has a `README.md` with this frontmatter:
 id: "<NNN>"
 title: "<Descriptive title>"
 status: research | specifying | open-questions | planned | in-progress | done | archived
-jira: ""             # Optional: Jira issue key (e.g., YAI-042)
-owner: ""            # Who is responsible
+jira: "" # Optional: Jira issue key (e.g., YAI-042)
+owner: "" # Who is responsible
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
@@ -137,15 +142,15 @@ updated: YYYY-MM-DD
 
 **Status values:**
 
-| Status | Meaning |
-|--------|---------|
-| `research` | Investigating the problem space |
-| `specifying` | Writing or refining the spec |
-| `open-questions` | Blocked on decisions the user must make |
-| `planned` | Plan and/or tasks defined, ready for implementation |
-| `in-progress` | Implementation underway |
-| `done` | All acceptance criteria met, work complete |
-| `archived` | Ticket closed without completion. **The reason for archival (superseded, cancelled, etc.) must be documented clearly in the ticket's README.md body.** |
+| Status           | Meaning                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `research`       | Investigating the problem space                                                                                                                        |
+| `specifying`     | Writing or refining the spec                                                                                                                           |
+| `open-questions` | Blocked on decisions the user must make                                                                                                                |
+| `planned`        | Plan and/or tasks defined, ready for implementation                                                                                                    |
+| `in-progress`    | Implementation underway                                                                                                                                |
+| `done`           | All acceptance criteria met, work complete                                                                                                             |
+| `archived`       | Ticket closed without completion. **The reason for archival (superseded, cancelled, etc.) must be documented clearly in the ticket's README.md body.** |
 
 ## Ticket Lifecycle
 
@@ -153,16 +158,16 @@ updated: YYYY-MM-DD
 Research → Specify → Plan → Define Tasks → Implement → Done
 ```
 
-| Phase | Files Produced | Requires User Validation |
-|-------|---------------|--------------------------|
-| Research | Research.md | No (user may review) |
-| Specify | Spec.md, Decisions.md, Dependencies.md | **Yes — user must validate Spec.md** |
-| Plan | Plan.md | **Yes — user must confirm Plan.md** |
-| Define Tasks | Tasks.md | **Yes — user must validate Tasks.md** |
-| Implement | Code + tests | Per task as appropriate |
-| Done | Update README.md status, Changelog.md | **Yes — user confirms completion** |
+| Phase        | Files Produced                         | Requires User Validation              |
+| ------------ | -------------------------------------- | ------------------------------------- |
+| Research     | Research.md                            | No (user may review)                  |
+| Specify      | Spec.md, Decisions.md, Dependencies.md | **Yes — user must validate Spec.md**  |
+| Plan         | Plan.md                                | **Yes — user must confirm Plan.md**   |
+| Define Tasks | Tasks.md                               | **Yes — user must validate Tasks.md** |
+| Implement    | Code + tests                           | Per task as appropriate               |
+| Done         | Update README.md status, Changelog.md  | **Yes — user confirms completion**    |
 
-**Any participant (human or agent) can execute any phase.** The lifecycle defines the *order*, not who does what. The user may write the spec themselves, or the agent may do the research. Flexibility is expected.
+**Any participant (human or agent) can execute any phase.** The lifecycle defines the _order_, not who does what. The user may write the spec themselves, or the agent may do the research. Flexibility is expected.
 
 ## Drift Detection
 
@@ -193,12 +198,15 @@ Create an Architecture Decision Record when:
 **Ticket**: <link to related ticket, if any>
 
 ## Context
+
 What situation or problem prompted this decision?
 
 ## Decision
+
 What did we decide?
 
 ## Consequences
+
 What are the trade-offs? What becomes easier? What becomes harder?
 ```
 

--- a/skills/spec-driven/SKILL.md
+++ b/skills/spec-driven/SKILL.md
@@ -16,6 +16,7 @@ This skill is part of a set of four skills designed to work together:
 | **spec-driven** (this skill) | Methodology reference — structure, formats, rules |
 | **specs-setup** | Initialize `specs/` for a new project |
 | **specs-tickets** | Create and execute tickets through their lifecycle |
+| **specs-review** | Audit specs health, consistency, and drift |
 
 If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding. All three skills should be installed together.
 

--- a/skills/spec-driven/references/templates.md
+++ b/skills/spec-driven/references/templates.md
@@ -1,0 +1,416 @@
+# Document Templates
+
+Complete templates for every document in the spec-driven methodology.
+
+---
+
+## specs/README.md
+
+```markdown
+# <Project Name>
+
+> <One-line project description>
+
+## Status
+
+| Metric | Value |
+|--------|-------|
+| Active tickets | 0 |
+| Last updated | YYYY-MM-DD |
+
+## Active Tickets
+
+| # | Title | Status | Owner |
+|---|-------|--------|-------|
+
+## Recently Completed
+
+| # | Title | Completed |
+|---|-------|-----------|
+
+## Recent Decisions
+
+| ADR | Title | Date |
+|-----|-------|------|
+
+## Navigation
+
+- [Vision](Vision.md)
+- [PRD](PRD.md)
+- [Goals](Goals.md)
+- [Architecture](Architecture/README.md)
+- [Glossary](Glossary.md)
+- [Changelog](Changelog.md)
+- [Decisions](decisions/)
+- [Tickets](tickets/)
+```
+
+---
+
+## specs/Vision.md
+
+```markdown
+# Vision
+
+## Vision Statement
+
+What is this project and why does it exist? What future are we building toward?
+
+## Problem Statement
+
+What problem are we solving? Who experiences this problem and what is the impact?
+
+## Target Audience
+
+Who are the primary users? Describe personas if applicable.
+
+| Persona | Description | Key Needs |
+|---------|-------------|-----------|
+| | | |
+```
+
+---
+
+## specs/PRD.md
+
+```markdown
+# Product Requirements Document
+
+## Functional Requirements
+
+### FR-1: <Requirement title>
+
+<Description>
+
+### FR-2: <Requirement title>
+
+<Description>
+
+## Non-Functional Requirements
+
+### Performance
+
+### Security
+
+### Scalability
+
+### Accessibility
+
+## Scope
+
+### In Scope
+
+### Out of Scope
+
+## Assumptions & Constraints
+```
+
+---
+
+## specs/Goals.md
+
+```markdown
+# Goals
+
+## Success Metrics
+
+How do we measure success? Define quantitative and qualitative indicators.
+
+| Metric | Target | How Measured |
+|--------|--------|-------------|
+| | | |
+
+## Milestones
+
+| Milestone | Description | Target Date | Status |
+|-----------|-------------|-------------|--------|
+| | | | |
+```
+
+---
+
+## specs/Architecture/README.md
+
+```markdown
+# Architecture
+
+## System Overview
+
+High-level description of the system and its purpose.
+
+## Architecture Diagram
+
+Describe or include a diagram of the system architecture.
+
+## Key Components
+
+| Component | Responsibility |
+|-----------|---------------|
+| | |
+
+## Technology Stack
+
+| Layer | Technology | Rationale |
+|-------|-----------|-----------|
+| | | |
+
+## Key Constraints & Trade-offs
+
+Document important architectural constraints and the trade-offs made.
+
+## Sub-documents
+
+Link to detailed architecture documents as they are created:
+
+_(none yet)_
+```
+
+---
+
+## specs/Glossary.md
+
+```markdown
+# Glossary
+
+| Term | Definition |
+|------|-----------|
+| | |
+```
+
+---
+
+## specs/Changelog.md
+
+```markdown
+# Changelog
+
+All notable changes to this project are documented here. Entries are in reverse chronological order.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+```
+
+---
+
+## specs/decisions/ADR-NNN-\<title\>.md
+
+```markdown
+# ADR-NNN: <Title>
+
+**Status**: Proposed | Accepted | Deprecated | Superseded by ADR-NNN
+**Date**: YYYY-MM-DD
+**Ticket**: <link to related ticket, if any>
+
+## Context
+
+What situation or problem prompted this decision?
+
+## Decision
+
+What did we decide?
+
+## Consequences
+
+What are the trade-offs? What becomes easier? What becomes harder?
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/README.md
+
+```yaml
+---
+id: "<NNN>"
+title: "<Descriptive title>"
+status: research
+jira: ""
+owner: ""
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+```
+
+```markdown
+# <NNN> — <Title>
+
+<One-paragraph summary of what this ticket covers and why.>
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/Research.md
+
+```markdown
+# Research: <Title>
+
+## Objective
+
+What are we trying to learn or decide?
+
+## Findings
+
+### <Topic 1>
+
+### <Topic 2>
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| | | |
+
+## Recommendation
+
+Based on findings, what do we recommend?
+
+## References
+
+- <links to relevant docs, articles, code>
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/Spec.md
+
+```markdown
+# Spec: <Title>
+
+## User Stories
+
+### US-1: <Story title>
+
+**As a** <persona>, **I want** <action>, **so that** <benefit>.
+
+### US-2: <Story title>
+
+**As a** <persona>, **I want** <action>, **so that** <benefit>.
+
+## Acceptance Criteria
+
+- [ ] <Criterion 1>
+- [ ] <Criterion 2>
+- [ ] <Criterion 3>
+
+## Scope
+
+### In Scope
+
+### Out of Scope
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/Plan.md
+
+```markdown
+# Plan: <Title>
+
+## Approach
+
+Describe the implementation strategy at a high level.
+
+## Key Design Decisions
+
+Document important choices made during planning and their rationale.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| | | | |
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/Tasks.md
+
+```markdown
+# Tasks: <Title>
+
+## Task List
+
+- [ ] **Task 1**: <Description>
+- [ ] **Task 2**: <Description>
+- [ ] **Task 3**: <Description>
+
+## Completion Criteria
+
+All tasks checked off and acceptance criteria from Spec.md verified.
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/Dependencies.md
+
+```markdown
+# Dependencies: <Title>
+
+## Blocked By
+
+| Ticket | Title | Status | Impact |
+|--------|-------|--------|--------|
+| | | | |
+
+## Blocks
+
+| Ticket | Title | Impact |
+|--------|-------|--------|
+| | | |
+
+## External Dependencies
+
+List any external systems, APIs, or third-party dependencies.
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/Decisions.md
+
+```markdown
+# Decisions: <Title>
+
+## Open
+
+Questions that need a decision before work can proceed.
+
+### Q1: <Question>
+
+**Context**: <Why this matters>
+**Options**:
+1. <Option A> — <trade-offs>
+2. <Option B> — <trade-offs>
+
+**Suggested**: <Agent's recommendation>
+**Decision**: _Pending_
+
+## Resolved
+
+Decisions that have been made. Kept as a record.
+
+### Q1: <Question>
+
+**Decision**: <What was decided>
+**Date**: YYYY-MM-DD
+**Rationale**: <Why>
+```
+
+---
+
+## tickets/\<NNN\>-\<slug\>/Journal.md
+
+```markdown
+# Journal: <Title>
+
+Chronological record of how this ticket evolved. Not a chat transcript — a curated summary of key decisions, pivots, and process.
+
+## YYYY-MM-DD
+
+- <Event or decision>
+```

--- a/skills/specs-review/SKILL.md
+++ b/skills/specs-review/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: specs-review
+description: "Review the health of a spec-driven project. Use when: checking if specs are up to date; detecting drift between code and specs; finding stale or incomplete tickets; auditing consistency across Vision, PRD, Goals, Architecture, and tickets. Triggers on: 'specs review', 'spec health', 'check specs', 'audit specs', 'are specs up to date', 'drift check', 'stale tickets', 'spec consistency'."
+---
+
+# Specs Review
+
+Audit the health and consistency of a project's spec-driven documentation.
+
+## Skill Dependencies
+
+This skill is part of a set of skills designed to work together:
+
+- **spec-driven** — Methodology reference (structure, formats, rules)
+- **specs-setup** — Initialize `specs/` for a new project
+- **specs-tickets** — Create and execute tickets through their lifecycle
+- **specs-review** (this skill) — Audit specs health and consistency
+
+If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
+
+**Always load the [spec-driven](../spec-driven/SKILL.md) skill first** for the full methodology reference.
+
+## Procedure
+
+### 1. Structural Completeness
+
+Verify all required files exist:
+
+- [ ] `specs/README.md`
+- [ ] `specs/Vision.md`
+- [ ] `specs/PRD.md`
+- [ ] `specs/Goals.md`
+- [ ] `specs/Architecture/README.md`
+- [ ] `specs/Glossary.md`
+- [ ] `specs/Changelog.md`
+- [ ] `specs/decisions/` directory
+- [ ] `specs/tickets/` directory
+
+Report any missing files. Suggest running `specs-setup` if critical files are absent.
+
+### 2. Document Quality
+
+For each project-level document, check:
+
+| Document | Check |
+|----------|-------|
+| `Vision.md` | Has vision statement, problem statement, and target audience? |
+| `PRD.md` | Has functional requirements, non-functional requirements, and scope? Are requirements numbered (FR-1, FR-2...)? |
+| `Goals.md` | Has measurable success metrics? Are milestones defined with target dates? |
+| `Architecture/README.md` | Has system overview, key components, and tech stack? Links to sub-documents if they exist? |
+| `Glossary.md` | Has at least a few terms? Are terms used consistently in other documents? |
+| `Changelog.md` | Is up to date with recent completed tickets? |
+| `README.md` | Does the active tickets table match actual ticket statuses? Is the "last updated" date recent? |
+
+Flag documents that are empty templates (never filled in) or have placeholder content.
+
+### 3. Ticket Health
+
+Scan all ticket folders in `specs/tickets/` and check each one:
+
+**Frontmatter integrity:**
+- Does every ticket have a `README.md` with valid frontmatter (`id`, `title`, `status`, `created`, `updated`)?
+- Are status values valid (`research`, `specifying`, `open-questions`, `planned`, `in-progress`, `done`, `archived`)?
+
+**Lifecycle consistency:**
+- Does a ticket marked `in-progress` have a `Tasks.md` with at least some unchecked items?
+- Does a ticket marked `done` have all acceptance criteria in `Spec.md` checked off?
+- Does a ticket marked `planned` have both `Spec.md` and `Plan.md`?
+- Does a ticket marked `archived` have a documented reason in its README.md body?
+
+**Stale tickets:**
+- Any ticket with status `in-progress` or `research` whose `updated` date is more than 2 weeks old? Flag as potentially stale.
+- Any ticket with status `open-questions` that has been waiting for decisions? Flag with the pending questions.
+
+**Orphaned files:**
+- Any ticket folder missing a `README.md`?
+- Any `Decisions.md` with items still in the Open section for a ticket that has moved past `specifying`?
+
+Report findings as a table:
+
+| # | Title | Status | Issues |
+|---|-------|--------|--------|
+| 001 | ... | in-progress | Stale (last updated 3 weeks ago) |
+| 002 | ... | done | Acceptance criteria not all checked |
+
+### 4. Cross-Reference Consistency
+
+Check that documents reference each other correctly:
+
+- **README.md dashboard vs. reality**: Do the "Active Tickets" and "Recently Completed" tables match actual ticket statuses?
+- **ADR references**: Are ADRs referenced in the tickets that triggered them? Are ADR-modified documents (Vision, PRD, Goals, Architecture) updated accordingly?
+- **Glossary usage**: Scan Vision, PRD, and Architecture for domain terms. Are they defined in the Glossary? Are there Glossary terms that appear unused?
+- **Architecture sub-documents**: If `Architecture/README.md` links to sub-documents, do those files exist?
+
+### 5. Drift Detection
+
+Compare specs against the codebase:
+
+- Does the tech stack in `Architecture/README.md` match the actual dependencies (check `package.json`, `pyproject.toml`, `Cargo.toml`, etc.)?
+- Do the key components described in Architecture match the actual project structure?
+- Are there functional requirements in PRD.md that don't correspond to any ticket (planned or completed)?
+
+This step requires codebase analysis. Flag potential drift but note that **confirmation with the user is needed** — apparent drift may be intentional and just not yet documented.
+
+### 6. Report
+
+Summarize findings in three categories:
+
+**Critical** — Blocks correct agent behavior:
+- Missing ground truth documents (Vision, PRD, Architecture)
+- Tickets with invalid or missing frontmatter
+- Conflicts between specs and code that could lead to wrong implementation
+
+**Warning** — Should be addressed soon:
+- Stale tickets
+- Unresolved open questions
+- README dashboard out of sync
+- Empty or placeholder documents
+
+**Suggestion** — Improvements for completeness:
+- Missing Glossary terms
+- Tickets without Journal.md that had complex processes
+- Architecture that could benefit from sub-documents
+
+### 7. Propose Actions
+
+For each finding, propose a concrete action:
+
+- "Create ADR to document the React-to-Vue migration that happened in ticket 005"
+- "Update specs/README.md — tickets 003 and 004 are marked done but still in Active Tickets"
+- "Ticket 007 has been in-progress for 3 weeks with no updates — ask the owner for status"
+- "Add 'workspace' and 'campaign' to the Glossary — used in PRD but not defined"
+
+Ask the user which actions to take. Execute approved actions immediately.

--- a/skills/specs-review/SKILL.md
+++ b/skills/specs-review/SKILL.md
@@ -16,7 +16,11 @@ This skill is part of a set of skills designed to work together:
 - **specs-tickets** — Create and execute tickets through their lifecycle
 - **specs-review** (this skill) — Audit specs health and consistency
 
-If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
+If any of these skills are missing from the project, **instruct the user to install them** before proceeding:
+
+```bash
+npx skills add b12consulting/skills --skill <missing_skill>
+```
 
 **Always load the [spec-driven](../spec-driven/SKILL.md) skill first** for the full methodology reference.
 
@@ -42,15 +46,15 @@ Report any missing files. Suggest running `specs-setup` if critical files are ab
 
 For each project-level document, check:
 
-| Document | Check |
-|----------|-------|
-| `Vision.md` | Has vision statement, problem statement, and target audience? |
-| `PRD.md` | Has functional requirements, non-functional requirements, and scope? Are requirements numbered (FR-1, FR-2...)? |
-| `Goals.md` | Has measurable success metrics? Are milestones defined with target dates? |
-| `Architecture/README.md` | Has system overview, key components, and tech stack? Links to sub-documents if they exist? |
-| `Glossary.md` | Has at least a few terms? Are terms used consistently in other documents? |
-| `Changelog.md` | Is up to date with recent completed tickets? |
-| `README.md` | Does the active tickets table match actual ticket statuses? Is the "last updated" date recent? |
+| Document                 | Check                                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `Vision.md`              | Has vision statement, problem statement, and target audience?                                                   |
+| `PRD.md`                 | Has functional requirements, non-functional requirements, and scope? Are requirements numbered (FR-1, FR-2...)? |
+| `Goals.md`               | Has measurable success metrics? Are milestones defined with target dates?                                       |
+| `Architecture/README.md` | Has system overview, key components, and tech stack? Links to sub-documents if they exist?                      |
+| `Glossary.md`            | Has at least a few terms? Are terms used consistently in other documents?                                       |
+| `Changelog.md`           | Is up to date with recent completed tickets?                                                                    |
+| `README.md`              | Does the active tickets table match actual ticket statuses? Is the "last updated" date recent?                  |
 
 Flag documents that are empty templates (never filled in) or have placeholder content.
 
@@ -59,29 +63,33 @@ Flag documents that are empty templates (never filled in) or have placeholder co
 Scan all ticket folders in `specs/tickets/` and check each one:
 
 **Frontmatter integrity:**
+
 - Does every ticket have a `README.md` with valid frontmatter (`id`, `title`, `status`, `created`, `updated`)?
 - Are status values valid (`research`, `specifying`, `open-questions`, `planned`, `in-progress`, `done`, `archived`)?
 
 **Lifecycle consistency:**
+
 - Does a ticket marked `in-progress` have a `Tasks.md` with at least some unchecked items?
 - Does a ticket marked `done` have all acceptance criteria in `Spec.md` checked off?
 - Does a ticket marked `planned` have both `Spec.md` and `Plan.md`?
 - Does a ticket marked `archived` have a documented reason in its README.md body?
 
 **Stale tickets:**
+
 - Any ticket with status `in-progress` or `research` whose `updated` date is more than 2 weeks old? Flag as potentially stale.
 - Any ticket with status `open-questions` that has been waiting for decisions? Flag with the pending questions.
 
 **Orphaned files:**
+
 - Any ticket folder missing a `README.md`?
 - Any `Decisions.md` with items still in the Open section for a ticket that has moved past `specifying`?
 
 Report findings as a table:
 
-| # | Title | Status | Issues |
-|---|-------|--------|--------|
-| 001 | ... | in-progress | Stale (last updated 3 weeks ago) |
-| 002 | ... | done | Acceptance criteria not all checked |
+| #   | Title | Status      | Issues                              |
+| --- | ----- | ----------- | ----------------------------------- |
+| 001 | ...   | in-progress | Stale (last updated 3 weeks ago)    |
+| 002 | ...   | done        | Acceptance criteria not all checked |
 
 ### 4. Cross-Reference Consistency
 
@@ -107,17 +115,20 @@ This step requires codebase analysis. Flag potential drift but note that **confi
 Summarize findings in three categories:
 
 **Critical** — Blocks correct agent behavior:
+
 - Missing ground truth documents (Vision, PRD, Architecture)
 - Tickets with invalid or missing frontmatter
 - Conflicts between specs and code that could lead to wrong implementation
 
 **Warning** — Should be addressed soon:
+
 - Stale tickets
 - Unresolved open questions
 - README dashboard out of sync
 - Empty or placeholder documents
 
 **Suggestion** — Improvements for completeness:
+
 - Missing Glossary terms
 - Tickets without Journal.md that had complex processes
 - Architecture that could benefit from sub-documents

--- a/skills/specs-setup/SKILL.md
+++ b/skills/specs-setup/SKILL.md
@@ -14,6 +14,7 @@ This skill is part of a set of three skills designed to work together:
 - **spec-driven** — Methodology reference (structure, formats, rules)
 - **specs-setup** (this skill) — Initialize `specs/` for a new project
 - **specs-tickets** — Create and execute tickets through their lifecycle
+- **specs-review** — Audit specs health, consistency, and drift
 
 If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
 

--- a/skills/specs-setup/SKILL.md
+++ b/skills/specs-setup/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: specs-setup
+description: "Initialize the spec-driven project methodology. Use when: no specs/ folder exists; critical files like PRD.md, Vision.md, or Architecture/ are missing; setting up a new project for structured requirements and task management. Triggers on: 'setup specs', 'initialize specs', 'create PRD', 'start project methodology', 'missing specs', 'init specs', 'no specs folder'."
+---
+
+# Specs Setup
+
+Initialize the spec-driven methodology for a project. Run this when `specs/` doesn't exist or is missing critical files.
+
+## Skill Dependencies
+
+This skill is part of a set of three skills designed to work together:
+
+- **spec-driven** — Methodology reference (structure, formats, rules)
+- **specs-setup** (this skill) — Initialize `specs/` for a new project
+- **specs-tickets** — Create and execute tickets through their lifecycle
+
+If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
+
+**Always load the [spec-driven](../spec-driven/SKILL.md) skill first** for the full methodology reference. Load [templates](../spec-driven/references/templates.md) when creating documents.
+
+## Prerequisites
+
+Before setting up specs, check if the project has **coding standards** defined:
+
+- `.github/copilot-instructions.md` or `.github/instructions/*.instructions.md`
+- `CLAUDE.md`
+- Or equivalent
+
+If no coding standards exist, **prompt the user to create them before proceeding.** Specs define WHAT to build; coding standards define HOW to build it. Both are needed before any implementation work begins.
+
+## Procedure
+
+### 1. Assess Current State
+
+Check which of these exist:
+
+- [ ] `specs/` directory
+- [ ] `specs/README.md`
+- [ ] `specs/Vision.md`
+- [ ] `specs/PRD.md`
+- [ ] `specs/Goals.md`
+- [ ] `specs/Architecture/` directory
+- [ ] `specs/Architecture/README.md`
+- [ ] `specs/Glossary.md`
+- [ ] `specs/Changelog.md`
+- [ ] `specs/decisions/` directory
+- [ ] `specs/tickets/` directory
+
+Report what's missing and confirm with the user before creating anything.
+
+### 2. Create Missing Structure
+
+Create any missing directories and files using the templates from [templates.md](../spec-driven/references/templates.md).
+
+Create in this order:
+
+1. `specs/` directory
+2. `specs/decisions/` directory (add a `.gitkeep` if empty)
+3. `specs/tickets/` directory (add a `.gitkeep` if empty)
+4. `specs/Architecture/` directory
+5. `specs/Vision.md`
+6. `specs/PRD.md`
+7. `specs/Goals.md`
+8. `specs/Architecture/README.md`
+9. `specs/Glossary.md`
+10. `specs/Changelog.md`
+11. `specs/README.md` (last, because it links to everything above)
+
+### 3. Populate Vision.md
+
+Interview the user to fill in the vision. Ask about:
+
+1. **Vision statement**: What is this project? Why does it exist? What future are we building toward?
+2. **Problem statement**: What problem does it solve? Who feels this pain? What is the impact?
+3. **Target audience**: Who are the primary users or personas?
+
+Write Vision.md based on the user's answers. **Present it for review and confirmation.**
+
+If the project has existing documentation or a README, use it as input — but always confirm with the user rather than assuming.
+
+### 4. Populate PRD.md
+
+Interview the user to fill in the PRD. Ask about:
+
+1. **Functional requirements**: What are the key things the system must do?
+2. **Non-functional requirements**: Performance, security, scalability, accessibility needs?
+3. **Scope**: What's explicitly in scope? What's explicitly out of scope?
+4. **Assumptions & constraints**: What are we assuming? What limits us?
+
+Write PRD.md based on the user's answers. **Present it for review and confirmation.**
+
+### 5. Populate Goals.md
+
+Interview the user to fill in the goals. Ask about:
+
+1. **Success metrics**: How will we know it's successful? What are the quantitative and qualitative indicators?
+2. **Milestones**: What are the key milestones and their target dates?
+
+Write Goals.md based on the user's answers. **Present it for review and confirmation.**
+
+### 6. Populate Architecture
+
+If the project has **existing code**, analyze it and draft the architecture documentation:
+
+1. **System overview**: What does the system do at a high level?
+2. **Key components**: What are the major parts and their responsibilities?
+3. **Technology stack**: What technologies are used and why?
+4. **Key constraints**: What are the important architectural constraints and trade-offs?
+
+If the project is **new** (no code yet), work with the user to define the target architecture.
+
+**Present Architecture/README.md for review and confirmation.**
+
+Remember: keep it high-level. The architecture entry point should give someone a clear mental model of the system in under 5 minutes of reading. Split into sub-documents only when a section exceeds ~200 lines.
+
+### 7. Populate Glossary
+
+Scan the Vision, PRD, and Architecture for domain-specific terms. Draft definitions and **ask the user to confirm them.** Even a small initial glossary (5-10 terms) is valuable — it can grow over time.
+
+### 8. Create Instructions File
+
+Create a `.github/instructions/specs.instructions.md` file to ensure agents automatically load the spec-driven methodology when working with specs:
+
+```markdown
+---
+applyTo: "specs/**"
+---
+
+This project uses the spec-driven methodology. Load the `spec-driven` skill before making any changes to files in the specs/ folder.
+```
+
+If the `.github/instructions/` directory doesn't exist, create it.
+
+### 9. Finalize README
+
+Update `specs/README.md` with:
+
+- The project name and one-line description
+- Current status (likely "Setting up" or "No active tickets")
+- Working navigation links to all created documents
+
+### 10. Suggest Commit
+
+Suggest the user commits the initial specs:
+
+```
+docs: initialize spec-driven methodology
+```
+
+## Incremental Setup
+
+If `specs/` already exists but is incomplete, only create the missing pieces. Do not overwrite existing documents — they may contain work that shouldn't be lost. Instead, flag any inconsistencies or gaps and let the user decide how to resolve them.

--- a/skills/specs-setup/SKILL.md
+++ b/skills/specs-setup/SKILL.md
@@ -16,7 +16,11 @@ This skill is part of a set of three skills designed to work together:
 - **specs-tickets** — Create and execute tickets through their lifecycle
 - **specs-review** — Audit specs health, consistency, and drift
 
-If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
+If any of these skills are missing from the project, **instruct the user to install them** before proceeding:
+
+```bash
+npx skills add b12consulting/skills --skill <missing_skill>
+```
 
 **Always load the [spec-driven](../spec-driven/SKILL.md) skill first** for the full methodology reference. Load [templates](../spec-driven/references/templates.md) when creating documents.
 

--- a/skills/specs-tickets/SKILL.md
+++ b/skills/specs-tickets/SKILL.md
@@ -14,6 +14,7 @@ This skill is part of a set of three skills designed to work together:
 - **spec-driven** — Methodology reference (structure, formats, rules)
 - **specs-setup** — Initialize `specs/` for a new project
 - **specs-tickets** (this skill) — Create and execute tickets through their lifecycle
+- **specs-review** — Audit specs health, consistency, and drift
 
 If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
 

--- a/skills/specs-tickets/SKILL.md
+++ b/skills/specs-tickets/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: specs-tickets
+description: "Create new spec-driven tickets and resume existing ones through the full lifecycle: research, specification, planning, task definition, and implementation. Use when: the user describes new work to be done; continuing a previously started ticket; a feature, bug fix, or task needs planning and implementation; starting or resuming planned work on a project with specs/. Triggers on: 'new ticket', 'new feature', 'fix bug', 'implement', 'create ticket', 'I want to build', 'let us work on', 'new task', 'add feature', 'continue ticket', 'resume work', 'pick up where we left off', 'work on ticket', 'existing ticket', 'check ticket status', 'what is the state of ticket'."
+---
+
+# Specs Tickets
+
+Create and execute tickets through the spec-driven lifecycle, or resume work on existing ones.
+
+## Skill Dependencies
+
+This skill is part of a set of three skills designed to work together:
+
+- **spec-driven** — Methodology reference (structure, formats, rules)
+- **specs-setup** — Initialize `specs/` for a new project
+- **specs-tickets** (this skill) — Create and execute tickets through their lifecycle
+
+If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
+
+**Always load the [spec-driven](../spec-driven/SKILL.md) skill first** for the full methodology reference. Load [templates](../spec-driven/references/templates.md) when creating documents.
+
+## Prerequisites
+
+1. Verify `specs/` folder exists with `Vision.md`, `PRD.md`, `Goals.md`, and `Architecture/README.md`. If missing, prompt the user to run the [specs-setup](../specs-setup/SKILL.md) skill first.
+2. Read `specs/README.md`, then `specs/Vision.md`, `specs/PRD.md`, `specs/Goals.md`, and `specs/Architecture/README.md` to understand the project context.
+3. Check for coding standards (`.instructions.md`, `CLAUDE.md`, etc.). If missing, prompt the user to create them before implementation begins.
+
+---
+
+## Entry Point: New Ticket or Existing?
+
+Determine whether the user wants to **create a new ticket** or **continue an existing one**.
+
+- If the user describes new work → go to [New Ticket](#new-ticket)
+- If the user references an existing ticket → go to [Resume Ticket](#resume-ticket)
+- If unclear, ask the user
+
+---
+
+## New Ticket
+
+### Phase 0: Create Ticket
+
+1. Ask the user to describe the work to be done.
+2. Ask for the **Jira issue key** (optional — store in frontmatter if provided).
+3. Determine the next ticket number: scan `specs/tickets/` for the highest existing number and increment by one. If no tickets exist, start at `001`.
+4. Derive a short slug from the description (lowercase, hyphen-separated).
+5. Create the ticket folder and `README.md`:
+
+```
+specs/tickets/<NNN>-<slug>/README.md
+```
+
+Use this frontmatter:
+
+```yaml
+---
+id: "<NNN>"
+title: "<Descriptive title>"
+status: research
+jira: "<JIRA-KEY>"     # Omit if not provided
+owner: ""
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+```
+
+Follow with a one-paragraph summary of the ticket.
+
+Then proceed to [Phase 1: Research](#phase-1-research).
+
+---
+
+## Resume Ticket
+
+### 1. Identify the Ticket
+
+Ask the user which ticket to continue, or identify it from conversation context:
+
+- Ticket number (e.g., "ticket 003")
+- Jira key (e.g., "YAI-042") — scan ticket README frontmatter to find the match
+- Description (e.g., "the auth ticket") — scan ticket titles to find the best match
+
+If ambiguous, list active tickets from `specs/README.md` and ask the user to pick one.
+
+### 2. Read Ticket State
+
+Read the ticket's `README.md` and note the **status** from frontmatter. Then read **all existing documents** in the ticket folder to understand the full context.
+
+Summarize the current state for the user: what phase the ticket is in, what's been completed, and what comes next.
+
+### 3. Check for Drift
+
+Compare the ticket's documents against the current state of:
+
+- **`specs/Vision.md`** and **`specs/PRD.md`** — Have requirements changed since this ticket was written?
+- **`specs/Architecture/README.md`** — Has the architecture evolved?
+- **The codebase** — Has relevant code changed since the ticket was last worked on?
+
+If drift is detected:
+- Report the specific inconsistencies to the user
+- Discuss whether the ticket needs updating before continuing
+- If specs changed, the ticket may need its Spec.md or Plan.md updated
+- If code changed, completed tasks may need re-verification
+
+### 4. Resolve Blockers
+
+If the ticket status is `open-questions`:
+- Present the unresolved questions from `Decisions.md` to the user
+- Ask for decisions on each
+- Record decisions in the Resolved section of Decisions.md
+- Update ticket status once all questions are answered
+
+If the ticket has `Dependencies.md` with unresolved blockers:
+- Report the blocking tickets and their current status
+- Discuss whether to wait, work around, or re-scope
+
+### 5. Resume the Lifecycle
+
+Based on the current status, pick up at the appropriate phase:
+
+| Current Status | Next Action |
+|---------------|-------------|
+| `research` | Review Research.md findings. Proceed to [Phase 2: Specify](#phase-2-specify). |
+| `specifying` | Check if Spec.md has been validated. If yes, proceed to [Phase 3: Plan](#phase-3-plan). If no, present for validation. |
+| `open-questions` | Resolve questions (step 4), then return to previous phase. |
+| `planned` | Check if Tasks.md exists. If yes, present for validation. If no, proceed to [Phase 4: Define Tasks](#phase-4-define-tasks). |
+| `in-progress` | Check Tasks.md for uncompleted tasks. Continue from [Phase 5: Implement](#phase-5-implement). |
+| `done` | Inform the user the ticket is complete. Ask if they want to reopen or create a follow-up. |
+| `archived` | Inform the user the ticket was archived. Ask if they want to create a new ticket instead. |
+
+### 6. Update Journal
+
+Add a `Journal.md` entry (create the file if it doesn't exist) noting when work resumed, any drift discovered, and decisions made during this session.
+
+---
+
+## Ticket Lifecycle
+
+The lifecycle has six phases. Each produces specific documents. User validation is required at key checkpoints before proceeding.
+
+```
+┌──────────┐    ┌─────────┐    ┌──────┐    ┌─────────────┐    ┌───────────┐    ┌──────┐
+│ Research  │───▶│ Specify │───▶│ Plan │───▶│ Define Tasks│───▶│ Implement │───▶│ Done │
+└──────────┘    └─────────┘    └──────┘    └─────────────┘    └───────────┘    └──────┘
+                     ▲              ▲             ▲
+                  User           User          User
+                validates      confirms      validates
+```
+
+**Any participant (human or agent) can execute any phase.** The lifecycle defines the order, not who does what.
+
+---
+
+### Phase 1: Research
+
+**Goal**: Understand the problem space and gather information needed to write a good spec.
+
+1. Investigate the codebase, existing documentation, and any external resources relevant to the ticket.
+2. Identify technical constraints, existing patterns, and potential approaches.
+3. Document findings in `Research.md`:
+   - Objective: what we're trying to learn
+   - Findings: organized by topic
+   - Options considered with pros/cons
+   - Recommendation
+   - References
+4. Update ticket status to `research`.
+
+**Research.md is optional for straightforward tickets.** If the path is clear from the user's description, skip directly to Phase 2. A one-line bug fix doesn't need research, but a new feature with multiple possible approaches does.
+
+---
+
+### Phase 2: Specify
+
+**Goal**: Define what "done" looks like.
+
+1. Based on research findings (or the user's description), write `Spec.md`:
+   - **User stories**: Who wants what and why
+   - **Acceptance criteria**: Concrete, testable conditions that prove the work is done
+   - **Scope boundaries**: What's in scope and explicitly out of scope
+
+2. If the ticket has **cross-ticket dependencies**, create `Dependencies.md`:
+   - What this ticket is blocked by
+   - What this ticket blocks
+   - External dependencies
+
+3. If there are **unresolved questions** that block specification, create `Decisions.md`:
+   - List each question with context in the **Open** section
+   - Provide options with trade-offs for each
+   - Include a suggested answer for each
+   - **Ask the user to decide on ALL open questions before proceeding**
+   - Move resolved questions to the **Resolved** section with the decision, date, and rationale
+
+4. Update ticket status to `specifying` (or `open-questions` if questions exist).
+
+5. **Present Spec.md to the user for validation.**
+
+> **CHECKPOINT: Do not proceed to Phase 3 until the user has validated the spec.**
+
+---
+
+### Phase 3: Plan
+
+**Goal**: Define the implementation strategy.
+
+1. Based on the confirmed spec, write `Plan.md`:
+   - **Approach**: High-level implementation strategy
+   - **Key design decisions**: Important choices and their rationale
+   - **Risks & mitigations**: What could go wrong and how to handle it
+
+2. **Check alignment with Architecture/README.md.** If the plan requires architectural changes:
+   - Flag this to the user explicitly
+   - Propose an ADR in `specs/decisions/`
+   - Update `specs/Architecture/README.md` only after user approval
+
+3. Update ticket status to `planned`.
+
+4. **Present Plan.md to the user for confirmation.**
+
+> **CHECKPOINT: Do not proceed to Phase 4 until the user has confirmed the plan.**
+
+---
+
+### Phase 4: Define Tasks
+
+**Goal**: Break the plan into executable steps.
+
+1. Based on the confirmed plan, write `Tasks.md`:
+   - Concrete, actionable tasks as a checklist
+   - Each task should be small enough to complete and verify independently
+   - Order tasks by dependency (what must be done first)
+   - Include verification steps where appropriate (e.g., "run tests", "verify endpoint returns 200")
+
+2. Update ticket status to `planned` (if not already).
+
+3. **Present Tasks.md to the user for validation.**
+
+> **CHECKPOINT: Do not proceed to Phase 5 until the user has validated the tasks.**
+
+---
+
+### Phase 5: Implement
+
+**Goal**: Execute the tasks.
+
+1. Work through `Tasks.md` sequentially:
+   - Check off each task as it is completed
+   - If a task reveals the spec or plan needs updating, **pause implementation**:
+     - Update the relevant document
+     - Log the change in `Journal.md`
+     - Inform the user of the change
+     - Get confirmation before continuing if the change is significant
+
+2. **Drift detection during implementation**: If implementation reveals a conflict with Vision, PRD, Goals, or Architecture:
+   - **Alert the user immediately**
+   - Either create an ADR to update specs, or create a follow-up ticket to fix the code
+   - Do not silently deviate from specs
+
+3. Update ticket status to `in-progress`.
+
+---
+
+### Phase 6: Done
+
+1. Verify **all acceptance criteria** from Spec.md are met.
+2. Update ticket `README.md`:
+   - Set status to `done`
+   - Update the `updated` date
+3. Update `specs/README.md`:
+   - Move ticket from "Active Tickets" to "Recently Completed"
+4. Add an entry to `specs/Changelog.md` describing what was shipped.
+5. If any ground truth documents (Vision, PRD, Goals, Architecture) were updated during implementation, verify consistency across all references.
+
+---
+
+## Handling Changes Mid-Flight
+
+Requirements often change during implementation. When they do:
+
+1. Update `Spec.md` with the new or changed requirements.
+2. Log the change and rationale in `Journal.md`.
+3. If the change affects Vision, PRD, Goals, or Architecture, create an ADR.
+4. If the change invalidates completed tasks, update `Tasks.md` accordingly.
+5. Re-validate with the user if the change is significant.
+
+The spec is always the source of truth for the ticket, not the code. Keep them in sync.
+
+## Scaling Guidance
+
+- **Small tickets** (bug fix, config change): Phase 0 → Phase 2 → Phase 4 → Phase 5 → Phase 6. Skip Research and Plan.
+- **Medium tickets** (feature, refactor): All phases. Research may be brief.
+- **Large tickets** (new system, major redesign): All phases. Consider breaking into multiple tickets during Phase 4 if the task list exceeds ~15 items.

--- a/skills/specs-tickets/SKILL.md
+++ b/skills/specs-tickets/SKILL.md
@@ -16,7 +16,11 @@ This skill is part of a set of three skills designed to work together:
 - **specs-tickets** (this skill) — Create and execute tickets through their lifecycle
 - **specs-review** — Audit specs health, consistency, and drift
 
-If any of these skills are missing from the project, **instruct the user to install the full set** before proceeding.
+If any of these skills are missing from the project, **instruct the user to install them** before proceeding:
+
+```bash
+npx skills add b12consulting/skills --skill <missing_skill>
+```
 
 **Always load the [spec-driven](../spec-driven/SKILL.md) skill first** for the full methodology reference. Load [templates](../spec-driven/references/templates.md) when creating documents.
 
@@ -59,7 +63,7 @@ Use this frontmatter:
 id: "<NNN>"
 title: "<Descriptive title>"
 status: research
-jira: "<JIRA-KEY>"     # Omit if not provided
+jira: "<JIRA-KEY>" # Omit if not provided
 owner: ""
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
@@ -99,6 +103,7 @@ Compare the ticket's documents against the current state of:
 - **The codebase** — Has relevant code changed since the ticket was last worked on?
 
 If drift is detected:
+
 - Report the specific inconsistencies to the user
 - Discuss whether the ticket needs updating before continuing
 - If specs changed, the ticket may need its Spec.md or Plan.md updated
@@ -107,12 +112,14 @@ If drift is detected:
 ### 4. Resolve Blockers
 
 If the ticket status is `open-questions`:
+
 - Present the unresolved questions from `Decisions.md` to the user
 - Ask for decisions on each
 - Record decisions in the Resolved section of Decisions.md
 - Update ticket status once all questions are answered
 
 If the ticket has `Dependencies.md` with unresolved blockers:
+
 - Report the blocking tickets and their current status
 - Discuss whether to wait, work around, or re-scope
 
@@ -120,15 +127,15 @@ If the ticket has `Dependencies.md` with unresolved blockers:
 
 Based on the current status, pick up at the appropriate phase:
 
-| Current Status | Next Action |
-|---------------|-------------|
-| `research` | Review Research.md findings. Proceed to [Phase 2: Specify](#phase-2-specify). |
-| `specifying` | Check if Spec.md has been validated. If yes, proceed to [Phase 3: Plan](#phase-3-plan). If no, present for validation. |
-| `open-questions` | Resolve questions (step 4), then return to previous phase. |
-| `planned` | Check if Tasks.md exists. If yes, present for validation. If no, proceed to [Phase 4: Define Tasks](#phase-4-define-tasks). |
-| `in-progress` | Check Tasks.md for uncompleted tasks. Continue from [Phase 5: Implement](#phase-5-implement). |
-| `done` | Inform the user the ticket is complete. Ask if they want to reopen or create a follow-up. |
-| `archived` | Inform the user the ticket was archived. Ask if they want to create a new ticket instead. |
+| Current Status   | Next Action                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `research`       | Review Research.md findings. Proceed to [Phase 2: Specify](#phase-2-specify).                                               |
+| `specifying`     | Check if Spec.md has been validated. If yes, proceed to [Phase 3: Plan](#phase-3-plan). If no, present for validation.      |
+| `open-questions` | Resolve questions (step 4), then return to previous phase.                                                                  |
+| `planned`        | Check if Tasks.md exists. If yes, present for validation. If no, proceed to [Phase 4: Define Tasks](#phase-4-define-tasks). |
+| `in-progress`    | Check Tasks.md for uncompleted tasks. Continue from [Phase 5: Implement](#phase-5-implement).                               |
+| `done`           | Inform the user the ticket is complete. Ask if they want to reopen or create a follow-up.                                   |
+| `archived`       | Inform the user the ticket was archived. Ask if they want to create a new ticket instead.                                   |
 
 ### 6. Update Journal
 


### PR DESCRIPTION
I am adding these skills as a lightweight alternative to BMAD and Copilot SpecKit.
I feel that both BMAD and Copilot SpecKit are too heavy in terms of the concepts and flows they impose on users.
This PR adds four skills that replicate much of the desired behaviour from the other spec-driven frameworks:
1. A specs/ folder contains documentation about the state and goals of the project and also a record of how it evolved into this state
2. A project development flow involving writing and validation of specs, plan and tasks before starting to work.

I'll try this out on some projects and will probably refine them over time.